### PR TITLE
Remove FriendshipsService.has_followed

### DIFF
--- a/friendships/api/serializers.py
+++ b/friendships/api/serializers.py
@@ -34,8 +34,6 @@ class FollowerSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
     def get_has_followed(self, obj):
         if self.context['request'].user.is_anonymous:
             return False
-        # <TODO> 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
-        # 我们将在后序的课程中解决这个问题
         return obj.from_user_id in self.following_user_id_set
 
 
@@ -50,8 +48,6 @@ class FollowingSerializer(serializers.ModelSerializer, FollowingUserIdSetMixin):
     def get_has_followed(self, obj):
         if self.context['request'].user.is_anonymous:
             return False
-        # <TODO> 这个部分会对每个 object 都去执行一次 SQL 查询，速度会很慢，如何优化呢？
-        # 我们将在后序的课程中解决这个问题
         return obj.to_user_id in self.following_user_id_set
 
 

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -38,13 +38,6 @@ class FriendshipsService(object):
         return [friendship.from_user for friendship in friendships]
 
     @classmethod
-    def has_followed(cls, from_user, to_user):
-        return Friendship.objects.filter(
-            from_user=from_user,
-            to_user=to_user,
-        ).exists()
-
-    @classmethod
     def get_following_user_id_set(cls, from_user_id):
         key = FOLLOWINGS_PATTERN.format(user_id=from_user_id)
         user_id_set = cache.get(key)


### PR DESCRIPTION
Remove the FriendshipsService.has_followed() function since we are looking up a cached `following_user_id_set` in FollowerSerializer and FollowingSerializer's get_has_followed() property functions now.

This should have been done in https://github.com/xinluleo/django-twitter/pull/30